### PR TITLE
Allow overriding printVar behaviour with custom method

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ var typeColors = {
 var defaultOptions = {
   indent: '  ',
   newLine: '\n',
+  printVar: function printVar (variable) {
+    return JSON.stringify(variable);
+  },
   wrap: function wrap(type, text) {
     return chalk[typeColors[type]](text);
   },
@@ -21,11 +24,11 @@ function isObject(obj) {
   return typeof obj === 'object' && obj && !Array.isArray(obj);
 }
 
-function printVar(variable) {
+function printVar(variable, options) {
   if (typeof variable === 'function') {
     return variable.toString().replace(/\{.+\}/,'{}');
   } else if((typeof variable === 'object' || typeof variable === 'string') && !(variable instanceof RegExp)) {
-    return JSON.stringify(variable);
+    return options.printVar(variable)
   }
 
   return '' + variable;
@@ -45,11 +48,11 @@ function keyChanged(key, text, options) {
 }
 
 function keyRemoved(key, variable, options) {
-  return options.wrap('removed', '- ' + key + ': ' + printVar(variable)) + options.newLine;
+  return options.wrap('removed', '- ' + key + ': ' + printVar(variable, options)) + options.newLine;
 }
 
 function keyAdded(key, variable, options) {
-  return options.wrap('added', '+ ' + key + ': ' + printVar(variable)) + options.newLine;
+  return options.wrap('added', '+ ' + key + ': ' + printVar(variable, options)) + options.newLine;
 }
 
 function diffInternal(left, right, options) {
@@ -112,7 +115,7 @@ function diffInternal(left, right, options) {
     }
 
   } else if (left !== right) {
-    text = options.wrap('modified', printVar(left) + ' => ' + printVar(right));
+    text = options.wrap('modified', printVar(left, options) + ' => ' + printVar(right, options));
     changed = true;
   }
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function printVar(variable, options) {
   if (typeof variable === 'function') {
     return variable.toString().replace(/\{.+\}/,'{}');
   } else if((typeof variable === 'object' || typeof variable === 'string') && !(variable instanceof RegExp)) {
-    return options.printVar(variable)
+    return options.printVar(variable);
   }
 
   return '' + variable;


### PR DESCRIPTION
This PR extracts `printVar` out into the options, respecting the current implementation as the default, but allowing the caller to specify custom logic if necessary.

I needed this change to handle printing out variables in a diff. It was extensive enough for my needs, though I'm not 100% sure I covered every scenario where it would be useful. Hopefully you'll find it useful too.

Thanks in advance for taking a look!